### PR TITLE
typo fix, and reformat readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # nosuspend
 A little command-line tool for systems using systemd.
 
-nosuspend sets the systemd-inhibit flag with UID 0/root in order to block computer suspend while another command-line operation is running.
+nosuspend sets the systemd-inhibit flag with UID 0/root in order to block
+computer suspend while another command-line operation is running.
 
 ## installation
 
@@ -9,6 +10,12 @@ just clone the repo, `cd nosuspend`, then `sudo make install`
 
 ## how to use
 
-To use nosuspend, simply run before another command as in: `nosuspend appname -parameter for appname`
+To use nosuspend, simply run before another command as in:
+`nosuspend appname -parameter for appname`
 
-Note: when a suspend signal is sent while nosuspend is functioning, a dialog may appear saying something like "Authentication is required for suspending the system while an application asked to inhibit it." That dialog may ask for a root passphrase. Entering the passphrase and clicking "OK" should allpw the suspend to go ahead, overriding nosuspend. Ignoring, closing, or canceling the dialog will let nosuspend continue in blocking suspension.
+Note: when a suspend signal is sent while nosuspend is functioning, a dialog may
+appear saying something like "Authentication is required for suspending the
+system while an application asked to inhibit it." That dialog may ask for a root
+passphrase. Entering the passphrase and clicking "OK" should allow the suspend
+to go ahead, overriding nosuspend. Ignoring, closing, or canceling the dialog
+will let nosuspend continue in blocking suspension.


### PR DESCRIPTION
might as well reformat since I found a typo ("allpw")